### PR TITLE
Introduce soda cloud client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,4 +137,4 @@ dmypy.json
 # Jupyter notebook
 *.ipynb
 
-prefect_soda_cloud/test_client.py
+test_client.py

--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,5 @@ dmypy.json
 
 # Jupyter notebook
 *.ipynb
+
+prefect_soda_cloud/test_client.py

--- a/prefect_soda_cloud/exceptions.py
+++ b/prefect_soda_cloud/exceptions.py
@@ -1,0 +1,21 @@
+"""
+Exceptions to handle failures during interactions with Soda Cloud APIs.
+"""
+
+
+class TriggerScanException(Exception):
+    """
+    Exception to raise when there's an issue with Soda Cloud Trigger Scan API.
+    """
+
+
+class GetScanStatusException(Exception):
+    """
+    Exception to raise when there's an issue with Soda Cloud Get Scan Status API.
+    """
+
+
+class GetScanLogsException(Exception):
+    """
+    Exception to raise when there's an issue with Soda Cloud Get Scan Logs API.
+    """

--- a/prefect_soda_cloud/soda_cloud_client.py
+++ b/prefect_soda_cloud/soda_cloud_client.py
@@ -1,9 +1,21 @@
+"""
+A client to interact with Soda Cloud APIs.
+"""
+
 import base64
 from datetime import datetime
+from logging import Logger
 from time import sleep
 from typing import List, Optional
+from urllib.parse import urljoin
 
 from requests import Session
+
+from prefect_soda_cloud.exceptions import (
+    GetScanLogsException,
+    GetScanStatusException,
+    TriggerScanException,
+)
 
 
 class SodaCloudClient:
@@ -11,23 +23,52 @@ class SodaCloudClient:
     __TRIGGER_SCAN_V1_ENDPOINT = "api/v1/scans"
     __GET_SCAN_STATUS_V1_ENDPOINT = "api/v1/scans/{scanId}"
     __GET_SCAN_LOGS_V1_ENDPOINT = "api/v1/scans/{scanId}/logs"
+    __DEFAULT_WAIT_SECS_BETWEEN_API_CALLS = 5
 
-    def __init__(self, api_base_url: str, username: str, password: str) -> None:
+    def __init__(
+        self,
+        api_base_url: str,
+        username: str,
+        password: str,
+        logger: Logger,
+        wait_secs_between_api_calls: Optional[int],
+    ) -> None:
         """
         Create a `SodaCloudClient` object that can be used to interact
         with Soda Cloud APIs.
         """
         self.__api_base_url = api_base_url
-        self.__username = username
-        self.__password = password
-        self.__session = self.__get_session()
+        self.__secret = SodaCloudClient.__get_secret(
+            username=username, password=password
+        )
+        self.__logger = logger
+        self.__wait_secs_between_api_calls = (
+            wait_secs_between_api_calls
+            if wait_secs_between_api_calls and wait_secs_between_api_calls > 0
+            else self.__DEFAULT_WAIT_SECS_BETWEEN_API_CALLS
+        )
 
-    def __get_auth_header(self) -> str:
+    @property
+    def api_base_url(self) -> str:
+        """
+        Return API Base URL
+        """
+        return self.__api_base_url
+
+    @property
+    def wait_secs_between_api_calls(self) -> int:
+        """
+        Return wait time seconds between API calls
+        """
+        return self.__wait_secs_between_api_calls
+
+    @staticmethod
+    def __get_secret(username: str, password: str) -> str:
         """
         Return the value of the authorization header computed
         using the username and password
         """
-        secret = f"{self.__username}:{self.__password}".encode("utf-8")
+        secret = f"{username}:{password}".encode("utf-8")
         return base64.b64encode(secret).decode("utf-8")
 
     def __get_session(self) -> Session:
@@ -35,27 +76,34 @@ class SodaCloudClient:
         Create a `Session` object to interact with Soda Cloud APIs.
         """
         session = Session()
-        auth_header = self.__get_auth_header()
         session.headers = {
             "Content-Type": "application/x-www-form-urlencoded",
             "Accept": "application/json",
-            "Authorization": f"Basic {auth_header}",
+            "Authorization": f"Basic {self.__secret}",
         }
         return session
+
+    def __get_api_url(self, endpoint: str) -> str:
+        """
+        Return the full API URL by joining the base URL
+        and the given endpoint.
+        """
+        return urljoin(self.api_base_url, endpoint)
 
     def trigger_scan(self, scan_name: str, data_timestamp: Optional[datetime]) -> str:
         """
         Trigger a Soda Scan given its name and return the corresponding Scan ID.
-        Uses [Trigger Scan](https://docs.soda.io/api-docs/public-cloud-api-v1.html#/operations/POST/api/v1/scans)
+        Uses [Trigger Scan](https://docs.soda.io/api-docs/public-cloud-api-v1.html#/operations/POST/api/v1/scans) # noqa
         """
-        url = f"{self.__api_base_url}/{self.__TRIGGER_SCAN_V1_ENDPOINT}"
+        url = self.__get_api_url(endpoint=self.__TRIGGER_SCAN_V1_ENDPOINT)
         payload = {"scanDefinition": scan_name}
         if data_timestamp:
             payload["dataTimestamp"] = data_timestamp.isoformat()
 
-        with self.__session.post(url=url, data=payload) as response:
+        session = self.__get_session()
+        with session.post(url=url, data=payload) as response:
             if response.status_code != 201:
-                raise Exception(response.json())
+                raise TriggerScanException(response.json())
 
         return response.headers["X-Soda-Scan-Id"]
 
@@ -63,50 +111,55 @@ class SodaCloudClient:
         """
         Return dict that contains information about the run status
         of the scan given the corresponding Scan ID.
-        Uses [Get Scan Status](https://docs.soda.io/api-docs/public-cloud-api-v1.html#/operations/GET/api/v1/scans/{scanId})
+        Uses [Get Scan Status](https://docs.soda.io/api-docs/public-cloud-api-v1.html#/operations/GET/api/v1/scans/{scanId}) # noqa
         """
         get_scan_status_endpoint = self.__GET_SCAN_STATUS_V1_ENDPOINT.format(
             scanId=scan_id
         )
-        url = f"{self.__api_base_url}/{get_scan_status_endpoint}"
+        url = self.__get_api_url(endpoint=get_scan_status_endpoint)
 
-        with self.__session.get(url=url) as response:
+        session = self.__get_session()
+        with session.get(url=url) as response:
             if response.status_code != 200:
-                raise Exception(response.json())
+                raise GetScanStatusException(response.json())
 
         return response.json()
 
     def get_scan_logs(self, scan_id: str) -> List[dict]:
         """
-        TODO
+        Return the list of log messages generated by a scan
+        give the Scan ID.
+        Uses [Get Scan Logs](https://docs.soda.io/api-docs/public-cloud-api-v1.html#/operations/GET/api/v1/scans/{scanId}/logs) # noqa
         """
         get_scan_logs_endpoint = self.__GET_SCAN_LOGS_V1_ENDPOINT.format(scanId=scan_id)
-        url = f"{self.__api_base_url}/{get_scan_logs_endpoint}"
+        url = self.__get_api_url(endpoint=get_scan_logs_endpoint)
+        is_scan_ended = False
 
-        is_scan_complete = False
-
-        while not is_scan_complete:
+        # Ensure the scan execution is finished
+        while not is_scan_ended:
             scan_status = self.get_scan_status(scan_id=scan_id)
             if "ended" not in scan_status:
-                print("Waiting for scan to finish...")
-                sleep(5)
+                self.__logger.info("Waiting for scan to finish execution...")
+                sleep(self.__wait_secs_between_api_calls)
             else:
-                is_scan_complete = True
+                is_scan_ended = True
 
-        content = []
+        logs = []
         is_last_log_message = False
 
+        session = self.__get_session()
+        # Grab all log messages
         while not is_last_log_message:
-            with self.__session.get(url=url) as response:
+            with session.get(url=url) as response:
                 if response.status_code != 200:
-                    raise Exception(response.json())
+                    raise GetScanLogsException(response.json())
 
             data = response.json()
-            content.extend(data["content"])
+            logs.extend(data["content"])
             is_last_log_message = data["last"]
 
             if not is_last_log_message:
-                print("Waiting for more logs...")
-                sleep(5)
+                self.__logger.info("Waiting for more logs...")
+                sleep(self.__wait_secs_between_api_calls)
 
-        return content
+        return logs

--- a/prefect_soda_cloud/soda_cloud_client.py
+++ b/prefect_soda_cloud/soda_cloud_client.py
@@ -1,0 +1,112 @@
+import base64
+from datetime import datetime
+from time import sleep
+from typing import List, Optional
+
+from requests import Session
+
+
+class SodaCloudClient:
+
+    __TRIGGER_SCAN_V1_ENDPOINT = "api/v1/scans"
+    __GET_SCAN_STATUS_V1_ENDPOINT = "api/v1/scans/{scanId}"
+    __GET_SCAN_LOGS_V1_ENDPOINT = "api/v1/scans/{scanId}/logs"
+
+    def __init__(self, api_base_url: str, username: str, password: str) -> None:
+        """
+        Create a `SodaCloudClient` object that can be used to interact
+        with Soda Cloud APIs.
+        """
+        self.__api_base_url = api_base_url
+        self.__username = username
+        self.__password = password
+        self.__session = self.__get_session()
+
+    def __get_auth_header(self) -> str:
+        """
+        Return the value of the authorization header computed
+        using the username and password
+        """
+        secret = f"{self.__username}:{self.__password}".encode("utf-8")
+        return base64.b64encode(secret).decode("utf-8")
+
+    def __get_session(self) -> Session:
+        """
+        Create a `Session` object to interact with Soda Cloud APIs.
+        """
+        session = Session()
+        auth_header = self.__get_auth_header()
+        session.headers = {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Accept": "application/json",
+            "Authorization": f"Basic {auth_header}",
+        }
+        return session
+
+    def trigger_scan(self, scan_name: str, data_timestamp: Optional[datetime]) -> str:
+        """
+        Trigger a Soda Scan given its name and return the corresponding Scan ID.
+        Uses [Trigger Scan](https://docs.soda.io/api-docs/public-cloud-api-v1.html#/operations/POST/api/v1/scans)
+        """
+        url = f"{self.__api_base_url}/{self.__TRIGGER_SCAN_V1_ENDPOINT}"
+        payload = {"scanDefinition": scan_name}
+        if data_timestamp:
+            payload["dataTimestamp"] = data_timestamp.isoformat()
+
+        with self.__session.post(url=url, data=payload) as response:
+            if response.status_code != 201:
+                raise Exception(response.json())
+
+        return response.headers["X-Soda-Scan-Id"]
+
+    def get_scan_status(self, scan_id: str) -> dict:
+        """
+        Return dict that contains information about the run status
+        of the scan given the corresponding Scan ID.
+        Uses [Get Scan Status](https://docs.soda.io/api-docs/public-cloud-api-v1.html#/operations/GET/api/v1/scans/{scanId})
+        """
+        get_scan_status_endpoint = self.__GET_SCAN_STATUS_V1_ENDPOINT.format(
+            scanId=scan_id
+        )
+        url = f"{self.__api_base_url}/{get_scan_status_endpoint}"
+
+        with self.__session.get(url=url) as response:
+            if response.status_code != 200:
+                raise Exception(response.json())
+
+        return response.json()
+
+    def get_scan_logs(self, scan_id: str) -> List[dict]:
+        """
+        TODO
+        """
+        get_scan_logs_endpoint = self.__GET_SCAN_LOGS_V1_ENDPOINT.format(scanId=scan_id)
+        url = f"{self.__api_base_url}/{get_scan_logs_endpoint}"
+
+        is_scan_complete = False
+
+        while not is_scan_complete:
+            scan_status = self.get_scan_status(scan_id=scan_id)
+            if "ended" not in scan_status:
+                print("Waiting for scan to finish...")
+                sleep(5)
+            else:
+                is_scan_complete = True
+
+        content = []
+        is_last_log_message = False
+
+        while not is_last_log_message:
+            with self.__session.get(url=url) as response:
+                if response.status_code != 200:
+                    raise Exception(response.json())
+
+            data = response.json()
+            content.extend(data["content"])
+            is_last_log_message = data["last"]
+
+            if not is_last_log_message:
+                print("Waiting for more logs...")
+                sleep(5)
+
+        return content

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,3 +13,4 @@ mkdocs-gen-files
 interrogate
 coverage
 pillow
+responses

--- a/test_client.py.bck
+++ b/test_client.py.bck
@@ -1,0 +1,25 @@
+from soda_cloud_client import SodaCloudClient
+from pprint import pprint
+import logging
+
+
+if __name__ == "__main__":
+
+    logging.basicConfig()
+    logger = logging.getLogger("test")
+    logger.setLevel(logging.INFO)
+
+    c = SodaCloudClient(
+        api_base_url="https://cloud.soda.io",
+        username="a5ffba63-6e73-49f0-a8ca-4fc08b99a609",
+        password="f4wGP0tdBWXCOAeI58T4nSMgG0fIVh3uu4CYHv5hkMUy8zbYHwv4fg",
+        logger=logger,
+        wait_secs_between_api_calls=None
+
+    )
+
+    scan_id = c.trigger_scan(scan_name="playground_default_scan", data_timestamp=None)
+    #scan_status = c.get_scan_status(scan_id=scan_id)
+    #pprint(scan_status)
+    scan_logs = c.get_scan_logs(scan_id=scan_id)
+    pprint(scan_logs)

--- a/tests/test_soda_cloud_client.py
+++ b/tests/test_soda_cloud_client.py
@@ -1,0 +1,387 @@
+import logging
+from urllib.parse import urljoin
+
+import pytest
+import responses
+
+from prefect_soda_cloud.exceptions import (
+    GetScanLogsException,
+    GetScanStatusException,
+    TriggerScanException,
+)
+from prefect_soda_cloud.soda_cloud_client import SodaCloudClient
+
+
+def test_client_construction():
+    expected_api_base_url = "https://foo.bar"
+    expected_username = "user"
+    expected_password = "password"
+    expected_wait_secs_between_api_calls = 1
+
+    client = SodaCloudClient(
+        api_base_url=expected_api_base_url,
+        username=expected_username,
+        password=expected_password,
+        wait_secs_between_api_calls=expected_wait_secs_between_api_calls,
+        logger=logging.getLogger(),
+    )
+
+    assert client.api_base_url == expected_api_base_url
+    assert client.wait_secs_between_api_calls == expected_wait_secs_between_api_calls
+
+
+@responses.activate
+def test_trigger_scan_fails():
+    expected_api_base_url = "https://foo.bar"
+    expected_trigger_scan_url = urljoin(expected_api_base_url, "api/v1/scans")
+    expected_username = "user"
+    expected_password = "password"
+    expected_wait_secs_between_api_calls = 1
+    expected_error = {"error": "Error!"}
+
+    responses.add(
+        responses.POST, expected_trigger_scan_url, status=500, json=expected_error
+    )
+
+    client = SodaCloudClient(
+        api_base_url=expected_api_base_url,
+        username=expected_username,
+        password=expected_password,
+        wait_secs_between_api_calls=expected_wait_secs_between_api_calls,
+        logger=logging.getLogger(),
+    )
+
+    with pytest.raises(TriggerScanException, match=str(expected_error)):
+        client.trigger_scan(scan_name="fake_scan", data_timestamp=None)
+
+
+@responses.activate
+def test_trigger_scan_succeed():
+    expected_api_base_url = "https://foo.bar"
+    expected_trigger_scan_url = urljoin(expected_api_base_url, "api/v1/scans")
+    expected_username = "user"
+    expected_password = "password"
+    expected_wait_secs_between_api_calls = 1
+    expected_scan_id = "abc"
+
+    responses.add(
+        responses.POST,
+        expected_trigger_scan_url,
+        status=201,
+        headers={"X-Soda-Scan-Id": expected_scan_id},
+    )
+
+    client = SodaCloudClient(
+        api_base_url=expected_api_base_url,
+        username=expected_username,
+        password=expected_password,
+        wait_secs_between_api_calls=expected_wait_secs_between_api_calls,
+        logger=logging.getLogger(),
+    )
+
+    client.trigger_scan(scan_name="fake_scan", data_timestamp=None)
+    assert responses.calls[0].response.headers["X-Soda-Scan-Id"] == expected_scan_id
+
+
+@responses.activate
+def test_get_status_fails():
+    expected_api_base_url = "https://foo.bar"
+    scan_id = "abc"
+    get_scan_status_endpoint = f"api/v1/scans/{scan_id}"
+    expected_get_scan_status_url = urljoin(
+        expected_api_base_url, get_scan_status_endpoint
+    )
+    expected_username = "user"
+    expected_password = "password"
+    expected_wait_secs_between_api_calls = 1
+    expected_error = {"error": "Error!"}
+
+    responses.add(
+        responses.GET, expected_get_scan_status_url, status=500, json=expected_error
+    )
+
+    client = SodaCloudClient(
+        api_base_url=expected_api_base_url,
+        username=expected_username,
+        password=expected_password,
+        wait_secs_between_api_calls=expected_wait_secs_between_api_calls,
+        logger=logging.getLogger(),
+    )
+
+    with pytest.raises(GetScanStatusException, match=str(expected_error)):
+        client.get_scan_status(scan_id=scan_id)
+
+
+@responses.activate
+def test_get_scan_status_succeed():
+    expected_api_base_url = "https://foo.bar"
+    scan_id = "abc"
+    get_scan_status_endpoint = f"api/v1/scans/{scan_id}"
+    expected_get_scan_status_url = urljoin(
+        expected_api_base_url, get_scan_status_endpoint
+    )
+    expected_username = "user"
+    expected_password = "password"
+    expected_wait_secs_between_api_calls = 1
+    expected_status = {
+        "agentId": "the_agent",
+        "checks": [{"evaluationStatus": "pass", "id": "the_check"}],
+        "cloudUrl": "the_url",
+        "created": "the_creation_time",
+        "ended": "the_ended_time",
+        "errors": 0,
+        "failures": 0,
+        "id": scan_id,
+        "scanDefinition": {"id": "the_scan_definition_id", "name": "the_scan_name"},
+        "scanTime": "the_scan_time",
+        "started": "the_start_time",
+        "state": "queuing",
+        "submitted": "the_submitted_time",
+        "warnings": 0,
+    }
+
+    responses.add(
+        responses.GET, expected_get_scan_status_url, status=200, json=expected_status
+    )
+
+    client = SodaCloudClient(
+        api_base_url=expected_api_base_url,
+        username=expected_username,
+        password=expected_password,
+        wait_secs_between_api_calls=expected_wait_secs_between_api_calls,
+        logger=logging.getLogger(),
+    )
+
+    status = client.get_scan_status(scan_id=scan_id)
+    assert status == expected_status
+
+
+@responses.activate
+def test_get_scan_logs_fails():
+    expected_api_base_url = "https://foo.bar"
+    scan_id = "abc"
+    get_scan_status_endpoint = f"api/v1/scans/{scan_id}"
+    get_scan_logs_endpoint = f"api/v1/scans/{scan_id}/logs"
+
+    expected_get_scan_status_url = urljoin(
+        expected_api_base_url, get_scan_status_endpoint
+    )
+    expected_get_scan_logs_url = urljoin(expected_api_base_url, get_scan_logs_endpoint)
+
+    expected_username = "user"
+    expected_password = "password"
+    expected_wait_secs_between_api_calls = 1
+
+    expected_error = {"error": "Error!"}
+    expected_status = {
+        "agentId": "the_agent",
+        "checks": [{"evaluationStatus": "pass", "id": "the_check"}],
+        "cloudUrl": "the_url",
+        "created": "the_creation_time",
+        "ended": "the_ended_time",
+        "errors": 0,
+        "failures": 0,
+        "id": scan_id,
+        "scanDefinition": {"id": "the_scan_definition_id", "name": "the_scan_name"},
+        "scanTime": "the_scan_time",
+        "started": "the_start_time",
+        "state": "queuing",
+        "submitted": "the_submitted_time",
+        "warnings": 0,
+    }
+
+    responses.add(
+        responses.GET, expected_get_scan_status_url, status=200, json=expected_status
+    )
+
+    responses.add(
+        responses.GET, expected_get_scan_logs_url, status=500, json=expected_error
+    )
+
+    client = SodaCloudClient(
+        api_base_url=expected_api_base_url,
+        username=expected_username,
+        password=expected_password,
+        wait_secs_between_api_calls=expected_wait_secs_between_api_calls,
+        logger=logging.getLogger(),
+    )
+
+    with pytest.raises(GetScanLogsException, match=str(expected_error)):
+        client.get_scan_logs(scan_id=scan_id)
+
+    assert responses.calls[0].request.url == expected_get_scan_status_url
+    assert responses.calls[0].response.status_code == 200
+    assert responses.calls[1].request.url == expected_get_scan_logs_url
+
+
+@responses.activate
+def test_get_scan_logs_succeed():
+    expected_api_base_url = "https://foo.bar"
+    scan_id = "abc"
+    get_scan_status_endpoint = f"api/v1/scans/{scan_id}"
+    get_scan_logs_endpoint = f"api/v1/scans/{scan_id}/logs"
+
+    expected_get_scan_status_url = urljoin(
+        expected_api_base_url, get_scan_status_endpoint
+    )
+    expected_get_scan_logs_url = urljoin(expected_api_base_url, get_scan_logs_endpoint)
+
+    expected_username = "user"
+    expected_password = "password"
+    expected_wait_secs_between_api_calls = 1
+
+    expected_status = {
+        "agentId": "the_agent",
+        "checks": [{"evaluationStatus": "pass", "id": "the_check"}],
+        "cloudUrl": "the_url",
+        "created": "the_creation_time",
+        "ended": "the_ended_time",
+        "errors": 0,
+        "failures": 0,
+        "id": scan_id,
+        "scanDefinition": {"id": "the_scan_definition_id", "name": "the_scan_name"},
+        "scanTime": "the_scan_time",
+        "started": "the_start_time",
+        "state": "queuing",
+        "submitted": "the_submitted_time",
+        "warnings": 0,
+    }
+
+    expected_content = {"content": [{"row1": "log1"}, {"row2": "log2"}], "last": True}
+
+    responses.add(
+        responses.GET, expected_get_scan_status_url, status=200, json=expected_status
+    )
+
+    responses.add(
+        responses.GET, expected_get_scan_logs_url, status=200, json=expected_content
+    )
+
+    client = SodaCloudClient(
+        api_base_url=expected_api_base_url,
+        username=expected_username,
+        password=expected_password,
+        wait_secs_between_api_calls=expected_wait_secs_between_api_calls,
+        logger=logging.getLogger(),
+    )
+
+    logs = client.get_scan_logs(scan_id=scan_id)
+
+    assert responses.calls[0].request.url == expected_get_scan_status_url
+    assert responses.calls[0].response.status_code == 200
+    assert responses.calls[1].request.url == expected_get_scan_logs_url
+    assert logs == expected_content["content"]
+
+
+@responses.activate
+def test_get_logs_with_waiting_succeed():
+    expected_api_base_url = "https://foo.bar"
+    scan_id = "abc"
+    get_scan_status_endpoint = f"api/v1/scans/{scan_id}"
+    get_scan_logs_endpoint = f"api/v1/scans/{scan_id}/logs"
+
+    expected_get_scan_status_url = urljoin(
+        expected_api_base_url, get_scan_status_endpoint
+    )
+    expected_get_scan_logs_url = urljoin(expected_api_base_url, get_scan_logs_endpoint)
+
+    expected_username = "user"
+    expected_password = "password"
+    expected_wait_secs_between_api_calls = 1
+
+    # First call to get scan status
+    first_call_expected_status = {
+        "agentId": "the_agent",
+        "checks": [{"evaluationStatus": "pass", "id": "the_check"}],
+        "cloudUrl": "the_url",
+        "created": "the_creation_time",
+        "errors": 0,
+        "failures": 0,
+        "id": scan_id,
+        "scanDefinition": {"id": "the_scan_definition_id", "name": "the_scan_name"},
+        "scanTime": "the_scan_time",
+        "started": "the_start_time",
+        "state": "queuing",
+        "submitted": "the_submitted_time",
+        "warnings": 0,
+    }
+
+    responses.add(
+        responses.GET,
+        expected_get_scan_status_url,
+        status=200,
+        json=first_call_expected_status,
+    )
+
+    # Second call to get expected status
+    second_call_expected_status = {
+        "agentId": "the_agent",
+        "checks": [{"evaluationStatus": "pass", "id": "the_check"}],
+        "cloudUrl": "the_url",
+        "created": "the_creation_time",
+        "errors": 0,
+        "failures": 0,
+        "id": scan_id,
+        "scanDefinition": {"id": "the_scan_definition_id", "name": "the_scan_name"},
+        "ended": "the_ended_time",
+        "scanTime": "the_scan_time",
+        "started": "the_start_time",
+        "state": "completed",
+        "submitted": "the_submitted_time",
+        "warnings": 0,
+    }
+
+    responses.add(
+        responses.GET,
+        expected_get_scan_status_url,
+        status=200,
+        json=second_call_expected_status,
+    )
+
+    # First call to get scan logs
+    first_call_expected_logs = {
+        "content": [{"row1": "log1"}, {"row2": "log2"}],
+        "last": False,
+    }
+
+    responses.add(
+        responses.GET,
+        expected_get_scan_logs_url,
+        status=200,
+        json=first_call_expected_logs,
+    )
+
+    # Second call to get scan logs
+    second_call_expected_logs = {
+        "content": [{"row3": "log3"}, {"row4": "log4"}],
+        "last": True,
+    }
+
+    responses.add(
+        responses.GET,
+        expected_get_scan_logs_url,
+        status=200,
+        json=second_call_expected_logs,
+    )
+
+    client = SodaCloudClient(
+        api_base_url=expected_api_base_url,
+        username=expected_username,
+        password=expected_password,
+        wait_secs_between_api_calls=expected_wait_secs_between_api_calls,
+        logger=logging.getLogger(),
+    )
+
+    logs = client.get_scan_logs(scan_id=scan_id)
+
+    assert responses.calls[0].request.url == expected_get_scan_status_url
+    assert responses.calls[0].response.status_code == 200
+    assert responses.calls[1].request.url == expected_get_scan_status_url
+    assert responses.calls[1].response.status_code == 200
+    assert responses.calls[2].request.url == expected_get_scan_logs_url
+    assert responses.calls[2].response.status_code == 200
+    assert responses.calls[3].request.url == expected_get_scan_logs_url
+    assert (
+        logs
+        == first_call_expected_logs["content"] + second_call_expected_logs["content"]
+    )


### PR DESCRIPTION
This PR introduces a basic `SodaCloudClient` object that can be used to interact with the following Soda Cloud APIs:
- https://docs.soda.io/api-docs/public-cloud-api-v1.html#/operations/POST/api/v1/scans
- https://docs.soda.io/api-docs/public-cloud-api-v1.html#/operations/GET/api/v1/scans/{scanId}
- https://docs.soda.io/api-docs/public-cloud-api-v1.html#/operations/GET/api/v1/scans/{scanId}/logs